### PR TITLE
ビルドエラーを修正

### DIFF
--- a/boards/shields/mona2/mona2_r.overlay
+++ b/boards/shields/mona2/mona2_r.overlay
@@ -55,7 +55,7 @@
         cpi = <600>;
         //swap-xy;
         //invert-x; //COROPIT版ではコメントアウトを外す
-        //invert-y;　//COROPIT版ではコメントアウトを外す
+        //invert-y; //COROPIT版ではコメントアウトを外す
         evt-type = <INPUT_EV_REL>;
         x-input-code = <INPUT_REL_X>;
         y-input-code = <INPUT_REL_Y>;

--- a/config/west.yml
+++ b/config/west.yml
@@ -19,7 +19,7 @@ manifest:
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: badjeff
-      revision: main
+      revision: zmk-0.3
     # - name: zmk-driver-paw3222
     #   remote: sekigon-gonnoc
     #   revision: main


### PR DESCRIPTION
- 全角スペースが入っている影響でビルドエラーになるため修正
- [badjeff/zmk-pmw3610-driver](https://github.com/badjeff/zmk-pmw3610-driver)のZMK v0.3向けのブランチを使用するように修正