### PR TITLE
Sync upstream fixes: full-width space and driver revision

### DIFF
--- a/boards/shields/mona2/mona2_r.overlay
+++ b/boards/shields/mona2/mona2_r.overlay
@@ -55,7 +55,7 @@
         cpi = <600>;
         //swap-xy;
         //invert-x; //COROPIT版ではコメントアウトを外す
-        //invert-y;　//COROPIT版ではコメントアウトを外す
+        //invert-y; //COROPIT版ではコメントアウトを外す
         evt-type = <INPUT_EV_REL>;
         x-input-code = <INPUT_REL_X>;
         y-input-code = <INPUT_REL_Y>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -107,7 +107,7 @@
 &kp LCTRL         &kp LEFT_WIN  &mkp MB1  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 0 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 
-            sensor-bindings = <&scroll_up_down>, <&inc_dec_kp 0 0>;
+            sensor-bindings = <&scroll_up_down>;
         };
 
         layer_1 {
@@ -145,10 +145,10 @@
 
         layer_4 {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&trans  &trans  &trans  &trans  &trans            &trans       &trans        &trans        &trans        &trans        &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
-&trans  &trans  &trans  &trans  &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
+&trans  &kp LS(LG(N4))  &kp LS(LG(N5))  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&trans  &trans          &trans          &trans  &trans            &trans       &trans        &trans        &trans        &trans        &trans
+&trans  &trans          &trans          &trans  &trans  &trans    &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
+&trans  &trans          &trans          &trans  &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -76,9 +76,9 @@
 
         default_layer {
             bindings = <
-&kp Q             &kp W         &kp E    &kp R          &kp T                                                          &kp Y        &kp U  &kp I      &kp O    &kp P
-&kp A             &kp S         &kp D    &kp F          &kp G                                  &kp F13                 &kp H        &kp J  &kp K      &kp L    &kp SEMICOLON
-&mt LEFT_SHIFT Z  &kp X         &kp C    &kp V          &kp B        &kp F14                   &kp F15                 &kp N        &kp M  &kp COMMA  &kp DOT  &kp SLASH
+&kp Q             &kp W         &kp E    &kp R          &kp T                                                          &kp Y        &kp U  &kp I     &kp O     &kp P
+&kp A             &kp S         &kp D    &kp F          &kp G                                  &kp AT_SIGN             &kp H        &kp J  &kp K     &kp L     &kp SEMICOLON
+&mt LEFT_SHIFT Z  &kp X         &kp C    &kp V          &kp B        &kp COMMA                 &kp PERIOD              &kp N        &kp M  &mkp MB1  &mkp MB2  &kp SLASH
 &kp LCTRL         &kp LEFT_WIN  &kp F16  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 5 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -101,10 +101,10 @@
 
         default_layer {
             bindings = <
-&kp Q             &kp W         &kp E     &kp R          &kp T                                                          &kp Y        &kp U  &kp I     &kp O     &kp P
-&kp A             &kp S         &kp D     &kp F          &kp G                                  &kp AT_SIGN             &kp H        &kp J  &kp K     &kp L     &kp SEMICOLON
-&mt LEFT_SHIFT Z  &kp X         &kp C     &kp V          &kp B        &kp COMMA                 &kp PERIOD              &kp N        &kp M  &mkp MB1  &mkp MB2  &kp SLASH
-&kp LCTRL         &kp LEFT_WIN  &mkp MB1  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 0 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
+&kp Q             &kp W            &kp E         &kp R          &kp T                                                          &kp Y        &kp U  &kp I     &kp O     &kp P
+&kp A             &kp S            &kp D         &kp F          &kp G                                  &kp AT_SIGN             &kp H        &kp J  &kp K     &kp L     &kp SEMICOLON
+&mt LEFT_SHIFT Z  &kp X            &kp C         &kp V          &kp B        &kp COMMA                 &kp PERIOD              &kp N        &kp M  &mkp MB1  &mkp MB2  &mkp MB1
+&kp ESCAPE        &kp RIGHT_SHIFT  &kp LEFT_GUI  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 0 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -33,6 +33,31 @@
             bindings = <&kp TAB>;
             key-positions = <11 12>;
         };
+
+        shift_tab {
+            bindings = <&kp LS(TAB)>;
+            key-positions = <12 13>;
+        };
+
+        double_quotation {
+            bindings = <&kp DOUBLE_QUOTES>;
+            key-positions = <18 19>;
+        };
+
+        equal {
+            bindings = <&kp EQUAL>;
+            key-positions = <8 9>;
+        };
+
+        single_quote {
+            bindings = <&kp SINGLE_QUOTE>;
+            key-positions = <20 19>;
+        };
+
+        minus {
+            bindings = <&kp MINUS>;
+            key-positions = <7 8>;
+        };
     };
 
     macros {
@@ -76,10 +101,10 @@
 
         default_layer {
             bindings = <
-&kp Q             &kp W         &kp E    &kp R          &kp T                                                          &kp Y        &kp U  &kp I     &kp O     &kp P
-&kp A             &kp S         &kp D    &kp F          &kp G                                  &kp AT_SIGN             &kp H        &kp J  &kp K     &kp L     &kp SEMICOLON
-&mt LEFT_SHIFT Z  &kp X         &kp C    &kp V          &kp B        &kp COMMA                 &kp PERIOD              &kp N        &kp M  &mkp MB1  &mkp MB2  &kp SLASH
-&kp LCTRL         &kp LEFT_WIN  &kp F16  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 5 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
+&kp Q             &kp W         &kp E     &kp R          &kp T                                                          &kp Y        &kp U  &kp I     &kp O     &kp P
+&kp A             &kp S         &kp D     &kp F          &kp G                                  &kp AT_SIGN             &kp H        &kp J  &kp K     &kp L     &kp SEMICOLON
+&mt LEFT_SHIFT Z  &kp X         &kp C     &kp V          &kp B        &kp COMMA                 &kp PERIOD              &kp N        &kp M  &mkp MB1  &mkp MB2  &kp SLASH
+&kp LCTRL         &kp LEFT_WIN  &mkp MB1  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 0 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 
             sensor-bindings = <&scroll_up_down>, <&inc_dec_kp 0 0>;
@@ -87,10 +112,10 @@
 
         layer_1 {
             bindings = <
-&kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3      &kp NUMBER_4       &kp NUMBER_5                    &kp NUMBER_6  &kp NUMBER_7          &kp NUMBER_8           &kp NUMBER_9  &kp NUMBER_0
-&trans        &trans        &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &trans                  &trans  &trans        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans        &kp BACKSLASH
-&trans        &trans        &trans            &trans             &trans        &trans    &trans  &trans        &trans                &trans                 &trans        &kp PIPE
-&trans        &trans        &trans            &trans             &trans        &trans    &trans  &trans                                                                   &trans
+&kp NUMBER_1  &kp NUMBER_2      &kp NUMBER_3       &kp NUMBER_4          &kp NUMBER_5                             &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
+&trans        &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS            &trans  &trans         &mkp MB1      &trans        &mkp MB2      &mkp MB3
+&trans        &trans            &trans             &trans                &trans                 &trans    &trans  &kp PAGE_UP    &trans        &trans        &trans        &kp BACKSLASH
+&trans        &trans            &trans             &trans                &trans                 &trans    &trans  &kp PAGE_DOWN                                            &kp PIPE
             >;
 
             sensor-bindings = <&scroll_right_left>;
@@ -98,10 +123,10 @@
 
         layer_2 {
             bindings = <
-&kp EXCLAMATION  &kp AT_SIGN  &kp POUND          &kp DOLLAR  &kp PERCENT                      &kp CARET  &kp AMPERSAND  &kp ASTERISK  &kp MINUS  &kp UNDERSCORE
-&kp GRAVE        &kp TILDE    &kp DOUBLE_QUOTES  &kp SQT     &trans                  &trans   &mkp MB3   &mkp MB1       &mkp MB2      &kp EQUAL  &kp PLUS
-&kp F1           &kp F2       &kp F3             &kp F4      &kp F5       &kp F11    &kp F12  &kp F6     &kp F7         &kp F8        &kp F9     &kp F10
-&trans           &trans       &trans             &trans      &trans       &trans     &trans   &trans                                             &trans
+&kp EXCLAMATION  &kp AT_SIGN  &kp POUND          &kp DOLLAR  &kp PERCENT                       &kp CARET  &kp AMPERSAND  &kp ASTERISK  &kp MINUS  &kp UNDERSCORE
+&kp GRAVE        &kp TILDE    &kp DOUBLE_QUOTES  &kp SQT     &kp QUESTION             &trans   &mkp MB3   &mkp MB1       &mkp MB2      &kp EQUAL  &kp PLUS
+&kp F1           &kp F2       &kp F3             &kp F4      &kp F5        &kp F11    &kp F12  &kp F6     &kp F7         &kp F8        &kp F9     &kp F10
+&trans           &trans       &trans             &trans      &trans        &trans     &trans   &trans                                             &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -109,10 +134,10 @@
 
         layer_3 {
             bindings = <
-&trans  &kp LC(LS(TAB))     &kp PRINTSCREEN         &kp LC(TAB)              &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
-&trans  &kp LG(LEFT_ARROW)  &kp LG(RIGHT_ARROW)     &kp LC(LG(LEFT_ARROW))   &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &kp LEFT_SHIFT      &kp LG(LS(LEFT_ARROW))  &kp LG(LS(RIGHT_ARROW))  &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
-&trans  &trans              &trans                  &trans                   &trans                   &trans    &trans  &trans                                                   &trans
+&kp ESC          &kp LC(LS(TAB))     &kp PRINTSCREEN         &kp LC(TAB)              &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
+&kp LGUI         &kp LG(LEFT_ARROW)  &kp LG(RIGHT_ARROW)     &kp LC(LG(LEFT_ARROW))   &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
+&kp RIGHT_SHIFT  &kp LEFT_SHIFT      &kp LG(LS(LEFT_ARROW))  &kp LG(LS(RIGHT_ARROW))  &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
+&trans           &trans              &trans                  &trans                   &trans                   &trans    &trans  &trans                                                   &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
@@ -124,28 +149,6 @@
 &trans  &trans  &trans  &trans  &trans            &trans       &trans        &trans        &trans        &trans        &trans
 &trans  &trans  &trans  &trans  &trans  &trans    &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
 &trans  &trans  &trans  &trans  &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
-            >;
-
-            sensor-bindings = <&scroll_up_down>;
-        };
-
-        MOUSE {
-            bindings = <
-&trans  &trans    &trans    &trans    &trans                    &trans  &trans    &trans    &trans    &trans
-&trans  &mkp MB3  &mkp MB2  &mkp MB1  &trans            &trans  &trans  &mkp MB1  &mkp MB2  &mkp MB3  &trans
-&trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans  &trans    &trans    &trans    &trans
-&trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans                                &trans
-            >;
-
-            sensor-bindings = <&scroll_up_down>;
-        };
-
-        SCROLL {
-            bindings = <
-&trans  &trans  &trans  &trans  &trans                    &trans  &trans  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans            &trans  &trans  &trans  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans  &trans  &trans  &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans                          &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -82,7 +82,7 @@
 &kp LCTRL         &kp LEFT_WIN  &kp F16  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 3 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 
-            sensor-bindings = <&scroll_up_down>;
+            sensor-bindings = <&scroll_up_down>, <&inc_dec_kp 0 0>;
         };
 
         layer_1 {

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -25,7 +25,7 @@
         compatible = "zmk,combos";
 
         layer4_ESC {
-            bindings = <&lt 4 ESC>;
+            bindings = <&lt 3 ESC>;
             key-positions = <39 38>;
         };
 
@@ -104,7 +104,7 @@
 &kp Q             &kp W            &kp E         &kp R          &kp T                                                          &kp Y        &kp U  &kp I     &kp O     &kp P
 &kp A             &kp S            &kp D         &kp F          &kp G                                  &kp AT_SIGN             &kp H        &kp J  &kp K     &kp L     &kp SEMICOLON
 &mt LEFT_SHIFT Z  &kp X            &kp C         &kp V          &kp B        &kp COMMA                 &kp PERIOD              &kp N        &kp M  &mkp MB1  &mkp MB2  &mkp MB1
-&kp ESCAPE        &kp RIGHT_SHIFT  &kp LEFT_GUI  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 0 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
+&kp ESCAPE        &kp RIGHT_SHIFT  &kp LEFT_GUI  &kp BACKSPACE  &lt 0 ENTER  &lt_to_layer_0 2 LANG2    &lt_to_layer_0 0 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -118,29 +118,18 @@
 &trans           &trans            &trans             &trans                &trans                 &trans       &trans        &none                                                    &kp PIPE
             >;
 
-            sensor-bindings = <&inc_dec_kp RS(PLUS) LS(MINUS)>;
-        };
-
-        layer_2 {
-            bindings = <
-&kp EXCLAMATION  &kp AT_SIGN  &kp POUND          &kp DOLLAR  &kp PERCENT                       &kp CARET  &kp AMPERSAND  &kp ASTERISK  &kp MINUS  &kp UNDERSCORE
-&kp GRAVE        &kp TILDE    &kp DOUBLE_QUOTES  &kp SQT     &kp QUESTION             &trans   &mkp MB3   &mkp MB1       &mkp MB2      &kp EQUAL  &kp PLUS
-&kp F1           &kp F2       &kp F3             &kp F4      &kp F5        &kp F11    &kp F12  &kp F6     &kp F7         &kp F8        &kp F9     &kp F10
-&trans           &trans       &trans             &trans      &trans        &trans     &trans   &trans                                             &trans
-            >;
-
-            sensor-bindings = <&scroll_up_down>;
+            sensor-bindings = <&inc_dec_kp RS(C_VOLUME_UP) LS(C_VOLUME_DOWN)>;
         };
 
         layer_3 {
             bindings = <
-&kp ESC          &kp LC(LS(TAB))  &msc SCRL_UP      &kp LC(TAB)              &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
-&kp LGUI         &msc SCRL_LEFT   &msc SCRL_DOWN    &msc SCRL_RIGHT          &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
-&kp RIGHT_SHIFT  &msc MOVE_X(10)  &msc MOVE_Y(-10)  &kp LG(LS(RIGHT_ARROW))  &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
-&trans           &trans           &trans            &trans                   &trans                   &trans    &trans  &trans                                                   &trans
+&kp ESC          &kp LC(LS(TAB))  &msc SCRL_UP    &kp LC(TAB)      &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
+&kp LGUI         &msc SCRL_LEFT   &msc SCRL_DOWN  &msc SCRL_RIGHT  &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
+&kp RIGHT_SHIFT  &none            &none           &none            &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
+&trans           &trans           &trans          &trans           &trans                   &trans    &trans  &trans                                                   &trans
             >;
 
-            sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
+            sensor-bindings = <&scroll_right_left>;
         };
 
         layer_4 {
@@ -151,7 +140,7 @@
 &trans  &trans          &trans          &trans  &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
             >;
 
-            sensor-bindings = <&scroll_up_down>;
+            sensor-bindings = <&inc_dec_kp C_BRIGHTNESS_INC C_BRIGHTNESS_DEC>;
         };
     };
 };

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -134,10 +134,10 @@
 
         layer_3 {
             bindings = <
-&kp ESC          &kp LC(LS(TAB))     &kp PRINTSCREEN         &kp LC(TAB)              &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
-&kp LGUI         &kp LG(LEFT_ARROW)  &kp LG(RIGHT_ARROW)     &kp LC(LG(LEFT_ARROW))   &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
-&kp RIGHT_SHIFT  &kp LEFT_SHIFT      &kp LG(LS(LEFT_ARROW))  &kp LG(LS(RIGHT_ARROW))  &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
-&trans           &trans              &trans                  &trans                   &trans                   &trans    &trans  &trans                                                   &trans
+&kp ESC          &kp LC(LS(TAB))  &msc SCRL_UP      &kp LC(TAB)              &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
+&kp LGUI         &msc SCRL_LEFT   &msc SCRL_DOWN    &msc SCRL_RIGHT          &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
+&kp RIGHT_SHIFT  &msc MOVE_X(10)  &msc MOVE_Y(-10)  &kp LG(LS(RIGHT_ARROW))  &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
+&trans           &trans           &trans            &trans                   &trans                   &trans    &trans  &trans                                                   &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -118,7 +118,7 @@
 &trans        &trans            &trans             &trans                &trans                 &trans    &trans  &kp PAGE_DOWN                                            &kp PIPE
             >;
 
-            sensor-bindings = <&scroll_right_left>;
+            sensor-bindings = <&inc_dec_kp RS(PLUS) LS(MINUS)>;
         };
 
         layer_2 {

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -112,10 +112,10 @@
 
         layer_1 {
             bindings = <
-&kp NUMBER_1  &kp NUMBER_2      &kp NUMBER_3       &kp NUMBER_4          &kp NUMBER_5                             &kp NUMBER_6   &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
-&trans        &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS            &trans  &trans         &mkp MB1      &trans        &mkp MB2      &mkp MB3
-&trans        &trans            &trans             &trans                &trans                 &trans    &trans  &kp PAGE_UP    &trans        &trans        &trans        &kp BACKSLASH
-&trans        &trans            &trans             &trans                &trans                 &trans    &trans  &kp PAGE_DOWN                                            &kp PIPE
+&kp NUMBER_1     &kp NUMBER_2      &kp NUMBER_3       &kp NUMBER_4          &kp NUMBER_5                                      &kp NUMBER_6  &kp NUMBER_7   &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
+&kp GRAVE        &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS               &kp QUESTION  &kp LCTRL     &kp AMPERSAND  &kp ASTERISK  &kp MINUS     &kp UNDERSCORE
+&kp EXCLAMATION  &kp AT_SIGN       &kp POUND          &kp DOLLAR            &kp PERCENT            &kp TILDE    &trans        &none         &trans         &trans        &trans        &kp BACKSLASH
+&trans           &trans            &trans             &trans                &trans                 &trans       &trans        &none                                                    &kp PIPE
             >;
 
             sensor-bindings = <&inc_dec_kp RS(PLUS) LS(MINUS)>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -125,7 +125,7 @@
             bindings = <
 &kp ESC          &kp LC(LS(TAB))  &msc SCRL_UP    &kp LC(TAB)      &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
 &kp LGUI         &msc SCRL_LEFT   &msc SCRL_DOWN  &msc SCRL_RIGHT  &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
-&kp RIGHT_SHIFT  &none            &none           &none            &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
+&kp RIGHT_SHIFT  &kp LG(F)        &kp LG(TAB)     &kp LG(GRAVE)    &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
 &trans           &trans           &trans          &trans           &trans                   &trans    &trans  &trans                                                   &trans
             >;
 
@@ -134,10 +134,10 @@
 
         layer_4 {
             bindings = <
-&trans  &kp LS(LG(N4))  &kp LS(LG(N5))  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&trans  &trans          &trans          &trans  &trans            &trans       &trans        &trans        &trans        &trans        &trans
-&trans  &trans          &trans          &trans  &trans  &trans    &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
-&trans  &trans          &trans          &trans  &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
+&trans  &kp LS(LG(N4))  &kp LS(LG(N5))  &kp LG(LC(N))  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&trans  &trans          &trans          &trans         &trans            &trans       &trans        &trans        &trans        &trans        &trans
+&trans  &trans          &trans          &trans         &trans  &trans    &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
+&trans  &trans          &trans          &trans         &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
             >;
 
             sensor-bindings = <&inc_dec_kp C_BRIGHTNESS_INC C_BRIGHTNESS_DEC>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -79,7 +79,7 @@
 &kp Q             &kp W         &kp E    &kp R          &kp T                                                          &kp Y        &kp U  &kp I      &kp O    &kp P
 &kp A             &kp S         &kp D    &kp F          &kp G                                  &kp F13                 &kp H        &kp J  &kp K      &kp L    &kp SEMICOLON
 &mt LEFT_SHIFT Z  &kp X         &kp C    &kp V          &kp B        &kp F14                   &kp F15                 &kp N        &kp M  &kp COMMA  &kp DOT  &kp SLASH
-&kp LCTRL         &kp LEFT_WIN  &kp F16  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 3 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
+&kp LCTRL         &kp LEFT_WIN  &kp F16  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 5 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
             >;
 
             sensor-bindings = <&scroll_up_down>, <&inc_dec_kp 0 0>;

--- a/config/west.yml
+++ b/config/west.yml
@@ -19,7 +19,7 @@ manifest:
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: badjeff
-      revision: main
+      revision: zmk-0.3
     # - name: zmk-driver-paw3222
     #   remote: sekigon-gonnoc
     #   revision: main


### PR DESCRIPTION
Incorporates stability fixes from upstream:

- Fix full-width space in mona2_r.overlay comment
- Pin zmk-pmw3610-driver to stable zmk-0.3 branch instead of main

These changes improve build reliability and stability.