### PR TITLE
zmk-rgbled-widgetのrevisionをv0.3に固定

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -9,7 +9,7 @@ manifest:
     # - name: sekigon-gonnoc  # <-- PAW3222
     #   url-base: https://github.com/sekigon-gonnoc
     - name: caksoylar  # <-- RGB LED
-      url-base: https://github.com/caksoylar  
+      url-base: https://github.com/caksoylar
     - name: zettaface  # <-- Input Processor Keybind
       url-base: https://github.com/zettaface
   projects:
@@ -25,7 +25,7 @@ manifest:
     #   revision: main
     - name: zmk-rgbled-widget
       remote: caksoylar
-      revision: main
+      revision: v0.3
     - name: zmk-input-processor-keybind
       remote: zettaface
       revision: main


### PR DESCRIPTION
[zmk-rgbled-widget](https://github.com/caksoylar/zmk-rgbled-widget)がZMKのmainブランチのボード名変更に合わせて変更された影響でビルドが通らなくなっているので、v0.3に固定して修正しました。

ビルド結果は以下で確認できます。
https://github.com/kot149/zmk-config-moNa2-v2/actions/runs/22279064392