### PR TITLE
トラックボールCPIを下げて打鍵時の誤AML発動を軽減

### DIFF
--- a/boards/shields/mona2/mona2.dtsi
+++ b/boards/shields/mona2/mona2.dtsi
@@ -90,7 +90,7 @@
         compatible = "zmk,input-listener";
         status = "disabled";
         input-processors = 
-            <&zip_xy_transform INPUT_TRANSFORM_Y_INVERT>;         //Y軸反転
+            <&zip_xy_transform INPUT_TRANSFORM_Y_INVERT>,         //Y軸反転
             //<&zip_xy_transform INPUT_TRANSFORM_XY_SWAP>,        //X軸とY軸の入れ替え
             //<&zip_xy_transform INPUT_TRANSFORM_X_INVERT>,       //X軸反転
             <&zip_temp_layer 5 500>;                            //オートマウスレイヤーの選択

--- a/boards/shields/mona2/mona2.dtsi
+++ b/boards/shields/mona2/mona2.dtsi
@@ -93,7 +93,7 @@
             <&zip_xy_transform INPUT_TRANSFORM_Y_INVERT>;         //Y軸反転
             //<&zip_xy_transform INPUT_TRANSFORM_XY_SWAP>,        //X軸とY軸の入れ替え
             //<&zip_xy_transform INPUT_TRANSFORM_X_INVERT>,       //X軸反転
-            //<&zip_temp_layer 5 500>;                            //オートマウスレイヤーの選択
+            <&zip_temp_layer 5 500>;                            //オートマウスレイヤーの選択
     };
 
     left_encoder: encoder_left {

--- a/boards/shields/mona2/mona2_r.overlay
+++ b/boards/shields/mona2/mona2_r.overlay
@@ -54,8 +54,8 @@
         irq-gpios = <&gpio0 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; //P0.02を指定(MOTION)
         cpi = <600>;
         //swap-xy;
-        //invert-x; //COROPIT版ではコメントアウトを外す
-        //invert-y; //COROPIT版ではコメントアウトを外す
+        invert-x;
+        invert-y;
         evt-type = <INPUT_EV_REL>;
         x-input-code = <INPUT_REL_X>;
         y-input-code = <INPUT_REL_Y>;

--- a/boards/shields/mona2/mona2_r.overlay
+++ b/boards/shields/mona2/mona2_r.overlay
@@ -52,7 +52,7 @@
         reg = <0>;
         spi-max-frequency = <2000000>;
         irq-gpios = <&gpio0 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; //P0.02を指定(MOTION)
-        cpi = <600>;
+        cpi = <400>;
         //swap-xy;
         invert-x;
         invert-y;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -83,10 +83,10 @@
 
         default_layer {
             bindings = <
-&td0              &kp W           &kp E                   &kp R             &kp T                                                          &kp Y        &kp U  &kp I      &kp O    &kp P
-&mt LCTRL A       &mt LEFT_ALT S  &mt LEFT_WIN D          &mt LEFT_SHIFT F  &kp G                                  &kp F13                 &kp H        &mt RIGHT_SHIFT J  &mt RIGHT_WIN K      &mt RIGHT_ALT L    &mt RCTRL MINUS
-&mt LEFT_SHIFT Z  &kp X           &kp C                   &kp V             &kp B        &kp F14                   &kp F15                 &kp N        &kp M  &kp COMMA  &kp DOT  &kp SLASH
-&kp LCTRL         &kp LEFT_WIN    &kp F16                 &mt LEFT_SHIFT LANG1     &lt 2 SPACE  &lt_to_layer_0 3 LANG1    &lt_to_layer_0 3 BACKSPACE  &lt 1 ENTER                             &kp TAB
+&td0              &kp W           &kp E           &kp R                 &kp T                                                              &kp Y        &kp U              &kp I            &kp O            &kp P
+&mt LCTRL A       &mt LEFT_ALT S  &mt LEFT_WIN D  &mt LEFT_SHIFT F      &kp G                                  &kp F13                     &kp H        &mt RIGHT_SHIFT J  &mt RIGHT_WIN K  &mt RIGHT_ALT L  &mt RCTRL MINUS
+&mt LEFT_SHIFT Z  &kp X           &kp C           &kp V                 &kp B        &kp F14                   &kp F15                     &kp N        &kp M              &kp COMMA        &kp DOT          &kp SLASH
+&kp LCTRL         &kp LEFT_WIN    &kp F16         &mt LEFT_SHIFT LANG1  &lt 2 SPACE  &lt_to_layer_0 3 LANG1    &lt_to_layer_0 3 BACKSPACE  &lt 1 ENTER                                                       &kp TAB
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -94,10 +94,10 @@
 
         layer_1 {
             bindings = <
-&kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3      &kp NUMBER_4       &kp NUMBER_5                    &kp NUMBER_6  &kp NUMBER_7          &kp NUMBER_8           &kp NUMBER_9  &kp NUMBER_0
-&trans        &trans        &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &trans                  &trans  &trans        &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans        &kp BACKSLASH
-&trans        &trans        &trans            &trans             &trans        &trans    &trans  &trans        &trans                &trans                 &trans        &kp PIPE
-&trans        &trans        &trans            &trans             &trans        &trans    &trans  &trans                                                                   &trans
+&kp LEFT_BRACKET  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp RIGHT_BRACKET                              &trans  &trans  &trans  &trans  &trans
+&kp SEMI          &kp NUMBER_4  &kp NUMBER_5  &kp NUMBER_6  &kp EQUAL                              &trans  &trans  &trans  &trans  &trans  &trans
+&kp GRAVE         &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp BACKSLASH      &trans              &trans  &trans  &trans  &trans  &trans  &trans
+&trans            &trans        &trans        &kp PERIOD    &kp NUMBER_0       &kp SINGLE_QUOTE    &trans  &trans                          &trans
             >;
 
             sensor-bindings = <&scroll_right_left>;
@@ -105,10 +105,10 @@
 
         layer_2 {
             bindings = <
-&kp EXCLAMATION  &kp AT_SIGN  &kp POUND          &kp DOLLAR  &kp PERCENT                      &kp CARET  &kp AMPERSAND  &kp ASTERISK  &kp MINUS  &kp UNDERSCORE
-&kp GRAVE        &kp TILDE    &kp DOUBLE_QUOTES  &kp SQT     &trans                  &trans   &mkp MB3   &mkp MB1       &mkp MB2      &kp EQUAL  &kp PLUS
-&kp F1           &kp F2       &kp F3             &kp F4      &kp F5       &kp F11    &kp F12  &kp F6     &kp F7         &kp F8        &kp F9     &kp F10
-&trans           &trans       &trans             &trans      &trans       &trans     &trans   &trans                                             &trans
+&kp LEFT_BRACE  &kp LS(N7)        &kp LS(NUMBER_8)  &kp LS(NUMBER_9)      &kp RIGHT_BRACE                                         &kp LG(Z)       &kp LG(V)  &kp LG(C)  &kp LG(X)        &kp LS(LG(Z))
+&kp COLON       &kp LS(NUMBER_4)  &kp LS(NUMBER_5)  &kp LS(NUMBER_6)      &kp PLUS                                    &trans      &kp LEFT_ARROW  &kp DOWN   &kp UP     &kp RIGHT_ARROW  &trans
+&kp TILDE       &kp LS(NUMBER_1)  &kp LS(NUMBER_2)  &kp LS(NUMBER_3)      &kp PIPE               &kp F11              &kp F12     &kp HOME        &kp PG_DN  &kp PG_UP  &kp END          &trans
+&trans          &trans            &trans            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DOUBLE_QUOTES    &kp DELETE  &trans                                                 &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -138,8 +138,8 @@
 
         MOUSE {
             bindings = <
-&trans  &trans    &trans    &trans    &trans                    &trans  &trans    &trans    &trans    &trans
-&trans  &mkp MB3  &mkp MB2  &mkp MB1  &trans            &trans  &trans  &mkp MB1  &mkp MB2  &mkp MB3  &trans
+&trans  &trans    &mkp MB3  &trans    &trans                    &trans  &trans    &mkp MB3  &trans    &trans
+&trans  &mkp MB2  &mo 6     &mkp MB1  &trans            &trans  &trans  &mkp MB1  &mo 6     &mkp MB2  &trans
 &trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans  &trans    &trans    &trans    &trans
 &trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans                                &trans
             >;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -94,10 +94,10 @@
 
         layer_1 {
             bindings = <
-&kp LEFT_BRACKET  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp RIGHT_BRACKET                              &trans  &trans  &trans  &trans  &trans
-&kp SEMI          &kp NUMBER_4  &kp NUMBER_5  &kp NUMBER_6  &kp EQUAL                              &trans  &trans  &trans  &trans  &trans  &trans
-&kp GRAVE         &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp BACKSLASH      &trans              &trans  &trans  &trans  &trans  &trans  &trans
-&trans            &trans        &trans        &kp PERIOD    &kp NUMBER_0       &kp SINGLE_QUOTE    &trans  &trans                          &trans
+&kp LEFT_BRACKET  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp RIGHT_BRACKET                                                 &kp LC(LG(UP_ARROW))    &trans                      &trans                 &trans                       &trans
+&kp SEMI          &kp NUMBER_4  &kp NUMBER_5  &kp NUMBER_6  &kp EQUAL                                   &kp LG(LC(UP_ARROW))  &kp LG(LC(LEFT_ARROW))  &kp LA(LG(LC(LEFT_ARROW)))  &kp LA(LS(LG(EQUAL)))  &kp LA(LG(LC(RIGHT_ARROW)))  &kp LG(LC(RIGHT_ARROW))
+&kp GRAVE         &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp BACKSLASH      &kp LG(LA(LS(LC(R))))    &kp LG(LC(DOWN))      &kp LC(LEFT_ARROW)      &trans                      &trans                 &trans                       &kp RIGHT_ARROW
+&trans            &trans        &trans        &kp PERIOD    &kp NUMBER_0       &kp SINGLE_QUOTE         &trans                &trans                                                                                                  &trans
             >;
 
             sensor-bindings = <&scroll_right_left>;
@@ -138,10 +138,10 @@
 
         MOUSE {
             bindings = <
-&trans  &trans    &mkp MB3  &trans    &trans                    &trans  &trans    &mkp MB3  &trans    &trans
-&trans  &mkp MB2  &mo 3     &mkp MB1  &trans            &trans  &trans  &mkp MB1  &mo 3     &mkp MB2  &trans
-&trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans  &trans    &trans    &trans    &trans
-&trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans                                &trans
+&trans  &trans    &mkp MB3  &trans    &trans                    &trans         &trans    &mkp MB3  &trans    &trans
+&trans  &mkp MB2  &mo 3     &mkp MB1  &trans            &trans  &kp LG(RIGHT)  &mkp MB1  &mo 3     &mkp MB2  &trans
+&trans  &trans    &trans    &trans    &trans  &trans    &trans  &kp LG(LEFT)   &trans    &trans    &trans    &trans
+&trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans                                       &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -139,7 +139,7 @@
         MOUSE {
             bindings = <
 &trans  &trans    &mkp MB3  &trans    &trans                    &trans  &trans    &mkp MB3  &trans    &trans
-&trans  &mkp MB2  &mo 6     &mkp MB1  &trans            &trans  &trans  &mkp MB1  &mo 6     &mkp MB2  &trans
+&trans  &mkp MB2  &mo 3     &mkp MB1  &trans            &trans  &trans  &mkp MB1  &mo 3     &mkp MB2  &trans
 &trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans  &trans    &trans    &trans    &trans
 &trans  &trans    &trans    &trans    &trans  &trans    &trans  &trans                                &trans
             >;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -69,6 +69,13 @@
 
             tap-ms = <20>;
         };
+
+        td0: tap_dance_0 {
+            compatible = "zmk,behavior-tap-dance";
+            #binding-cells = <0>;
+            tapping-term-ms = <200>;
+            bindings = <&kp Q>, <&kp ESC>;
+        };
     };
 
     keymap {
@@ -76,10 +83,10 @@
 
         default_layer {
             bindings = <
-&kp Q             &kp W         &kp E    &kp R          &kp T                                                          &kp Y        &kp U  &kp I      &kp O    &kp P
-&kp A             &kp S         &kp D    &kp F          &kp G                                  &kp F13                 &kp H        &kp J  &kp K      &kp L    &kp SEMICOLON
-&mt LEFT_SHIFT Z  &kp X         &kp C    &kp V          &kp B        &kp F14                   &kp F15                 &kp N        &kp M  &kp COMMA  &kp DOT  &kp SLASH
-&kp LCTRL         &kp LEFT_WIN  &kp F16  &kp BACKSPACE  &lt 2 ENTER  &lt_to_layer_0 3 LANG2    &lt_to_layer_0 3 LANG1  &lt 1 SPACE                             &kp LEFT_ALT
+&td0              &kp W           &kp E                   &kp R             &kp T                                                          &kp Y        &kp U  &kp I      &kp O    &kp P
+&mt LCTRL A       &mt LEFT_ALT S  &mt LEFT_WIN D          &mt LEFT_SHIFT F  &kp G                                  &kp F13                 &kp H        &mt RIGHT_SHIFT J  &mt RIGHT_WIN K      &mt RIGHT_ALT L    &mt RCTRL MINUS
+&mt LEFT_SHIFT Z  &kp X           &kp C                   &kp V             &kp B        &kp F14                   &kp F15                 &kp N        &kp M  &kp COMMA  &kp DOT  &kp SLASH
+&kp LCTRL         &kp LEFT_WIN    &kp F16                 &mt LEFT_SHIFT LANG1     &lt 2 SPACE  &lt_to_layer_0 3 LANG1    &lt_to_layer_0 3 BACKSPACE  &lt 1 ENTER                             &kp TAB
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/mona2.keymap
+++ b/config/mona2.keymap
@@ -105,10 +105,10 @@
 
         layer_2 {
             bindings = <
-&kp LEFT_BRACE  &kp LS(N7)        &kp LS(NUMBER_8)  &kp LS(NUMBER_9)      &kp RIGHT_BRACE                                         &kp LG(Z)       &kp LG(V)  &kp LG(C)  &kp LG(X)        &kp LS(LG(Z))
-&kp COLON       &kp LS(NUMBER_4)  &kp LS(NUMBER_5)  &kp LS(NUMBER_6)      &kp PLUS                                    &trans      &kp LEFT_ARROW  &kp DOWN   &kp UP     &kp RIGHT_ARROW  &trans
-&kp TILDE       &kp LS(NUMBER_1)  &kp LS(NUMBER_2)  &kp LS(NUMBER_3)      &kp PIPE               &kp F11              &kp F12     &kp HOME        &kp PG_DN  &kp PG_UP  &kp END          &trans
-&trans          &trans            &trans            &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DOUBLE_QUOTES    &kp DELETE  &trans                                                 &trans
+&kp LEFT_BRACE          &kp LS(N7)               &kp LS(NUMBER_8)      &kp LS(NUMBER_9)      &kp RIGHT_BRACE                                         &kp LG(Z)       &kp LG(V)  &kp LG(C)  &kp LG(X)        &kp LS(LG(Z))
+&mt LEFT_CONTROL COLON  &mt LS(LEFT_ALT) DOLLAR  &mt PERCENT LEFT_GUI  &mt LEFT_SHIFT CARET  &kp PLUS                                    &trans      &kp LEFT_ARROW  &kp DOWN   &kp UP     &kp RIGHT_ARROW  &trans
+&kp TILDE               &kp LS(NUMBER_1)         &kp LS(NUMBER_2)      &kp LS(NUMBER_3)      &kp PIPE               &kp F11              &kp F12     &kp HOME        &kp PG_DN  &kp PG_UP  &kp END          &trans
+&trans                  &trans                   &trans                &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp DOUBLE_QUOTES    &kp DELETE  &trans                                                 &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -116,10 +116,10 @@
 
         layer_3 {
             bindings = <
-&trans  &kp LC(LS(TAB))     &kp PRINTSCREEN         &kp LC(TAB)              &trans                                     &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
-&trans  &kp LG(LEFT_ARROW)  &kp LG(RIGHT_ARROW)     &kp LC(LG(LEFT_ARROW))   &kp LC(LG(RIGHT_ARROW))            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
-&trans  &kp LEFT_SHIFT      &kp LG(LS(LEFT_ARROW))  &kp LG(LS(RIGHT_ARROW))  &trans                   &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
-&trans  &trans              &trans                  &trans                   &trans                   &trans    &trans  &trans                                                   &trans
+&kp F9  &kp F10  &kp F11  &kp F12  &trans                    &trans  &kp HOME        &kp UP_ARROW    &kp END          &trans
+&kp F5  &kp F6   &kp F7   &kp F8   &trans            &trans  &trans  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW  &trans
+&kp F1  &kp F2   &kp F3   &kp F4   &trans  &trans    &trans  &trans  &kp DELETE      &kp PAGE_UP     &kp PAGE_DOWN    &trans
+&trans  &trans   &trans   &trans   &trans  &trans    &trans  &trans                                                   &trans
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;


### PR DESCRIPTION
## Summary
- トラックボールのCPI を 600 → 400 に変更
- 打鍵時のキーボードの振動でトラックボールが微小に動き、意図せずオートマウスレイヤー(AML)が発動する問題を軽減

## Test plan
- [ ] ファームウェアをビルドしてフラッシュ
- [ ] 通常のタイピング中にAMLが誤発動しないことを確認
- [ ] トラックボール操作時のカーソル移動が遅すぎないことを確認
- [ ] まだ敏感な場合は CPI をさらに 300 に下げることを検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)